### PR TITLE
Fix: Search results list closing issues

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -141,6 +141,23 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   const [url] = useState(getRequestUrl(props.requestUrl));
 
   const inputRef = useRef();
+  const containerRef = useRef();
+
+  useEffect(() => {
+    // This will close search results list when user clicks outside the container
+    const outsideClickHandler = (e) => {
+      if (containerRef.current?.contains(e.target)) {
+        return;
+      }
+      setListViewDisplayed(false);
+    };
+
+    if (listViewDisplayed && Platform.OS === 'web') {
+      document.addEventListener('click', outsideClickHandler);
+    }
+
+    return () => document.removeEventListener('click', outsideClickHandler);
+  }, [listViewDisplayed]);
 
   useEffect(() => {
     // This will load the default value's search results after the view has
@@ -623,12 +640,14 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         horizontal={true}
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
+        focusable={false}
       >
         <TouchableHighlight
           style={
             props.isRowScrollable ? { minWidth: '100%' } : { width: '100%' }
           }
           onPress={() => _onPress(rowData)}
+          onBlur={_onBlur}
           underlayColor={props.listUnderlayColor || '#c8c7cc'}
         >
           <View
@@ -799,6 +818,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         props.suppressDefaultStyles ? {} : defaultStyles.container,
         props.styles.container,
       ]}
+      ref={containerRef}
       pointerEvents='box-none'
     >
       {!props.textInputHide && (

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -144,6 +144,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   const containerRef = useRef();
 
   useEffect(() => {
+    if (Platform.OS !== 'web' || !listViewDisplayed) {
+      return;
+    }
     // This will close search results list when user clicks outside the container
     const outsideClickHandler = (e) => {
       if (containerRef.current?.contains(e.target)) {
@@ -152,9 +155,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       setListViewDisplayed(false);
     };
 
-    if (listViewDisplayed && Platform.OS === 'web') {
-      document.addEventListener('click', outsideClickHandler);
-    }
+    document.addEventListener('click', outsideClickHandler);
 
     return () => document.removeEventListener('click', outsideClickHandler);
   }, [listViewDisplayed]);

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -147,6 +147,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     if (Platform.OS !== 'web' || !listViewDisplayed) {
       return;
     }
+
     // This will close search results list when user clicks outside the container
     const outsideClickHandler = (e) => {
       if (containerRef.current?.contains(e.target)) {
@@ -155,9 +156,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       setListViewDisplayed(false);
     };
 
-    document.addEventListener('click', outsideClickHandler);
+    document.addEventListener('mousedown', outsideClickHandler);
 
-    return () => document.removeEventListener('click', outsideClickHandler);
+    return () => document.removeEventListener('mousedown', outsideClickHandler);
   }, [listViewDisplayed]);
 
   useEffect(() => {


### PR DESCRIPTION
cc: @NikkiWines 
I am focusing on these issues for now
1. Close the list when we click away (outside the address input and its list)
2. Close the list as soon as you focus away from the last item on the list.
3. Row is selected twice when using Tab navigation. 

Issue https://github.com/Expensify/App/issues/6235

https://user-images.githubusercontent.com/24370807/149243519-f378dc60-87f8-42e4-8083-37d35bfeeb1a.mp4

### How to test
1. Copy the whole code of GooglePlacesAutocomplete.js. 
2. Relace `node_modules/react-native-google-places-autocomplete/GooglePlacesAutocomplete.js` with the copied code.
3. Go to Bank Setup / Company Step.
4. Search for Address. 
5. Follow the https://github.com/Expensify/App/issues/6235 for more testing steps.